### PR TITLE
Support passthrough of PAE-enabled memory maps to kexec targets

### DIFF
--- a/include/fiwix/bios.h
+++ b/include/fiwix/bios.h
@@ -14,7 +14,9 @@
 
 struct bios_mem_map {
 	unsigned int from;
+	unsigned int from_hi;
 	unsigned int to;
+	unsigned int to_hi;
 	int type;
 };
 extern struct bios_mem_map bios_mem_map[NR_BIOS_MM_ENT];

--- a/kernel/kexec.c
+++ b/kernel/kexec.c
@@ -253,14 +253,14 @@ void kexec_multiboot1(void)
 	map_orig = map = (struct multiboot_mmap_entry *)esp;
 	/* setup the memory map */
 	for(n = 0; n < nmaps; n++) {
-		/* TODO pass PAE memory blocks on to the new kernel */
-		if (!bios_mem_map[n].from_hi && !bios_mem_map[n].to_hi) {
-			map->size = sizeof(struct multiboot_mmap_entry) - sizeof(map->size);
-			map->addr = bios_mem_map[n].from;
-			map->len = (bios_mem_map[n].to + 1) - bios_mem_map[n].from;
-			map->type = bios_mem_map[n].type;
-			map++;
-		}
+		map->size = sizeof(struct multiboot_mmap_entry) - sizeof(map->size);
+		map->addr = bios_mem_map[n].from_hi;
+		map->addr = map->addr << 32 | bios_mem_map[n].from;
+		map->len = bios_mem_map[n].to_hi;
+		map->len = map->len << 32 | bios_mem_map[n].to
+		map->len -= map->addr - 1;
+		map->type = bios_mem_map[n].type;
+		map++;
 	}
 
 	/* space reserved for the multiboot_info structure */


### PR DESCRIPTION
Right now, Fiwix has no support for PAE. However, this shouldn't prevent another, PAE-capable kernel kexec'd by Fiwix from discovering and using memory in PAE address space.

This PR adds support for passing PAE address space to both Multiboot- and Linux-style kexec targets.